### PR TITLE
:ambulance: Prevent sending algos to existing escrow as there is a race condition for this

### DIFF
--- a/algodex_api.js
+++ b/algodex_api.js
@@ -902,6 +902,7 @@ const AlgodexApi = {
     generateOrder : function (makerWalletAddr, n, d, min, assetId, includeMakerAddr) {
         return dexInternal.generateOrder(makerWalletAddr, n, d, min, assetId, includeMakerAddr);
     },
+
     getPlaceAlgosToBuyASAOrderIntoOrderbook : async function 
         getPlaceAlgosToBuyASAOrderIntoOrderbook(algodClient, makerWalletAddr, n, d, min, assetId, algoOrderSize, signAndSend, walletConnector) {
         console.debug("placeAlgosToBuyASAOrderIntoOrderbook makerWalletAddr, n, d, min, assetId",
@@ -926,13 +927,13 @@ const AlgodexApi = {
             }
         }
 
-        let escrowAccountInfo = await this.getAccountInfo(lsig.address());
+        // let escrowAccountInfo = await this.getAccountInfo(lsig.address());
 
-        if (escrowAccountInfo != null && escrowAccountInfo['apps-local-state'] != null
-                && escrowAccountInfo['apps-local-state'].length > 0
-                && escrowAccountInfo['apps-local-state'][0].id == ALGO_ESCROW_ORDER_BOOK_ID) {
-            alreadyOptedIntoOrderbook = true;
-        }
+        // if (escrowAccountInfo != null && escrowAccountInfo['apps-local-state'] != null
+        //         && escrowAccountInfo['apps-local-state'].length > 0
+        //         && escrowAccountInfo['apps-local-state'][0].id == ALGO_ESCROW_ORDER_BOOK_ID) {
+        //     alreadyOptedIntoOrderbook = true;
+        // }
 
         console.debug({makerAlreadyOptedIntoASA});
         console.debug({alreadyOptedIntoOrderbook});
@@ -941,7 +942,7 @@ const AlgodexApi = {
             algoOrderSize = constants.MIN_ASA_ESCROW_BALANCE;
         }
         console.debug("alreadyOptedIn: " + alreadyOptedIntoOrderbook);
-        console.debug("acct info:" + JSON.stringify(escrowAccountInfo));
+        // console.debug("acct info:" + JSON.stringify(escrowAccountInfo));
         
         let params = await algodClient.getTransactionParams().do();
         console.debug("sending trans to: " + lsig.address());
@@ -1012,25 +1013,24 @@ const AlgodexApi = {
             unsignedTxns.push(outerTxns[i].unsignedTxn);
         }
 
-        
-   let noteMetadata = { 
-       algoBalance: makerAccountInfo.amount,
-       asaBalance:(makerAccountInfo.assets && makerAccountInfo.assets.length > 0) ? makerAccountInfo.assets[0].amount : 0,
-       assetId: assetId, 
-       n:n, 
-       d:d, 
-       escrowAddr: escrowAccountInfo.address,
-       orderEntry: generatedOrderEntry,
-       escrowOrderType:"buy",
-       version: constants.ESCROW_CONTRACT_VERSION
-    }
-    // look into accuracy of above object
+        let noteMetadata = { 
+            algoBalance: makerAccountInfo.amount,
+            asaBalance:(makerAccountInfo.assets && makerAccountInfo.assets.length > 0) ? makerAccountInfo.assets[0].amount : 0,
+            assetId: assetId, 
+            n:n, 
+            d:d, 
+            escrowAddr: lsig.address(),
+            orderEntry: generatedOrderEntry,
+            escrowOrderType:"buy",
+            version: constants.ESCROW_CONTRACT_VERSION
+        };
+            // look into accuracy of above object
 
-       unsignedTxns = dexInternal.formatTransactionsWithMetadata(unsignedTxns, makerWalletAddr, noteMetadata, "open", "algo")
+        unsignedTxns = dexInternal.formatTransactionsWithMetadata(unsignedTxns, makerWalletAddr, noteMetadata, "open", "algo");
 
-       if (signAndSend) {
-        return await this.signAndSendTransactions(algodClient, outerTxns);
-    }
+        if (signAndSend) {
+            return await this.signAndSendTransactions(algodClient, outerTxns);
+        }
 
         
         if(!walletConnector || !walletConnector.connector.connected){this.assignGroups(unsignedTxns)};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@algodex/algodex-sdk",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@algodex/algodex-sdk",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "UNLICENSED",
       "dependencies": {
         "@json-rpc-tools/utils": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algodex/algodex-sdk",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "API calls for interacting with the Algorand blockchain",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There is a race condition where if a user funds an existing escrow with algos, and the indexer believes it was opted in, by the time they send their transaction the escrow might have opted out. Prevent this from happening.