### PR TITLE
:green_heart: Fix TEAL tests to use indexer

### DIFF
--- a/test/Teal.spec.js
+++ b/test/Teal.spec.js
@@ -28,6 +28,10 @@ config = {
 
 console.log("DEBUG_SMART_CONTRACT_SOURCE is: " + constants.DEBUG_SMART_CONTRACT_SOURCE);
 
+function sleep(seconds) {
+    console.log("Sleeping: " + seconds);
+    return new Promise(resolve => setTimeout(resolve, seconds * 1000));
+}
 
 describe('ALGO ESCROW ORDER BOOK (opt in test)', () => {
   test('Create algo escrow order book', async () => {
@@ -68,6 +72,8 @@ describe('ALGO ESCROW ORDER BOOK (opt in test)', () => {
 
     const result = await placeOrderTest.runTest(config, 800000, 1.2);
     expect (result).toBeTruthy();
+
+    await sleep(5);
 
     asaBalance = await testHelper.getAssetBalance(config.creatorAccount.addr, config.assetId);
     expect (asaBalance).toEqual(0);
@@ -629,7 +635,7 @@ describe('ASA ESCROW ORDER BOOK (with extra ASA opt-in txn during execution. Par
     // The execution will cause it to be opted in
     const result = await executeAsaOrderTest.runPartialExecTest(config, asaAmountReceiving, price);
     expect (result).toBeTruthy();
-    
+    await sleep(5);
     asaBalance = await testHelper.getAssetBalance(config.executorAccount.addr, config.assetId);
     expect (asaBalance).toBeGreaterThan(0);
     
@@ -670,11 +676,13 @@ describe('ASA ESCROW ORDER BOOK (with extra ASA opt-in txn during execution. Ful
   test ('Fully execute asa escrow order (with asa opt-in txn) ', async () => {
     let asaBalance = await testHelper.getAssetBalance(config.executorAccount.addr, config.assetId);
     expect (asaBalance).toBeNull();
+    await sleep(5);
 
     const price = 1.55;
     // The execution will cause it to be opted in
     const result = await executeAsaOrderTest.runFullExecTest(config, price);
     expect (result).toBeTruthy();
+    await sleep(5);
 
     asaBalance = await testHelper.getAssetBalance(config.executorAccount.addr, config.assetId);
     expect (asaBalance).toBeGreaterThan(0);

--- a/test_helper.js
+++ b/test_helper.js
@@ -23,7 +23,7 @@ const transactionGenerator = require('./generate_transaction_types.js');
 let ALGO_ESCROW_ORDER_BOOK_ID = -1;
 let ASA_ESCROW_ORDER_BOOK_ID = -1;
 
-const ALGOD_SERVER='https://testnet.algoexplorerapi.io';
+const ALGOD_SERVER='https://node.testnet.algoexplorerapi.io';
 const ALGOD_TOKEN = ''; //{ 'X-API-Key': 'VELyABA1dGqGbAVktbew4oACvp0c0298gMgYtYIb' }
 const ALGOD_PORT='';
 
@@ -40,12 +40,12 @@ const TestHelper = {
     },
 
     getAccountInfo : async function getAccountInfo(addr) {
-        //return algodex.getAccountInfo(addr);
+        return algodex.getAccountInfo(addr);
 
         // This is the old account info that uses algod, not the indexer
         // This is necessary for the tests to go faster as the indexer takes time to update.
 
-        try {
+        /*try {
             let port = (!!ALGOD_PORT) ? ':' + ALGOD_PORT : '';
 
             const response = await axios.get(ALGOD_SERVER + port +  "/v2/accounts/"+addr, {headers: {'X-Algo-API-Token': ALGOD_TOKEN}});
@@ -54,7 +54,7 @@ const TestHelper = {
         } catch (error) {
             console.error(error);
             throw new Error("getAccountInfo failed: ", error);
-        }
+        }*/
     },
 
     printOuterTransactions : function (outerTxns) {
@@ -68,11 +68,9 @@ const TestHelper = {
 
         if (error != null && error.response.body.message != null) {
             const msg = error.response.body.message;
-            if (msg.includes("rejected by logic err=assert failed")) {
+            if (msg.includes("rejected by logic err=")) {
                 hasKnownError = true;
             } else if (msg.includes("TEAL runtime encountered err opcode")) {
-                hasKnownError = true;
-            } else if (msg.includes("rejected by logic err=gtxn lookup TxnGroup") && msg.includes("but it only has") ) {
                 hasKnownError = true;
             } else {
                 throw("Unknown error type: " + msg);


### PR DESCRIPTION
Due to the Algoexplorer API deprecations, the TEAL tests need to be fixed to use the indexer. Some of the tests require waiting 5 seconds for the Algoexplorer indexer to catch up to the latest block. 

There is also a fix for checking the TEAL error code status.