### PR TITLE
🚑 Skip -1 exponents

### DIFF
--- a/algodex_api.js
+++ b/algodex_api.js
@@ -59,7 +59,7 @@ function scientificToString(n) {
         throw new TypeError('Must be a Big.js value!');
     }
     let num = Object.create(n);
-    if (typeof num.e !== 'undefined' && num.e !== 0) {
+    if (typeof num.e !== 'undefined' && num.e !== 0 && num.e !== -1) {
         if (num.e > 0) {
             // TODO: large numbers
         } else {

--- a/api.spec.js
+++ b/api.spec.js
@@ -5,19 +5,21 @@ it('should return sciToString', ()=>{
   expect(scientificToString(new Big(1e-7))).toEqual("0.0000001")
 })
 
-
-it('getNumDen', ()=>{
-  const res = getNumeratorAndDenominatorFromPrice(2.22);
-  expect(res).toEqual({
+it('getNumeratorAndDenominatorFromPrice', ()=>{
+  expect(getNumeratorAndDenominatorFromPrice(2.22)).toEqual({
     d: 222,
     n: 100,
   });
-});
-
-it('should add algorand units with scientific notation', ()=>{
-  const res = getNumeratorAndDenominatorFromPrice(1e-7);
-  expect(res).toEqual({
+  expect(getNumeratorAndDenominatorFromPrice(1e-7)).toEqual({
     d: 1,
     n: 10000000,
+  });
+  expect(getNumeratorAndDenominatorFromPrice(0.45)).toEqual({
+    d: 45,
+    n: 100,
+  })
+  expect(getNumeratorAndDenominatorFromPrice(10.45)).toEqual({
+    d: 1045,
+    n: 100
   });
 });


### PR DESCRIPTION
# ℹ Overview

Skip -1 exponents when checking for scientific notation