### PR TITLE
🐞Extra 0 on minAmount was causing the discrepancy

### DIFF
--- a/lib/wallet/getMinBalance.js
+++ b/lib/wallet/getMinBalance.js
@@ -38,7 +38,7 @@ function getMinAmount(
     const numByteSlice = wallet['apps-total-schema']['num-byte-slice'];
     minAmount += (25000+25000) * numByteSlice; // Total Bytes
   }
-  minAmount += 1000000;
+  minAmount += 100000;
 
   return minAmount;
 }


### PR DESCRIPTION
# ℹ Overview

`getMinBalance()` was incorrectly calculating the required minimum balance resulting in user's needing a larger balance than what is actually required. 

