### PR TITLE
✨ fetching of order properties when not provided

### DIFF
--- a/lib/AlgodexApi.js
+++ b/lib/AlgodexApi.js
@@ -507,6 +507,10 @@ AlgodexApi.prototype = {
     );
     return await execute({
       ...order,
+      version: typeof order.version === 'undefined' ? constants.ESCROW_CONTRACT_VERSION : order.version,
+      appId: typeof order.appId === 'undefined' ? await this.getAppId(order) : order.appId,
+      client: typeof order.algod !== 'undefined' ? order.algod : this.algod,
+      indexer: typeof order.indexer !== 'undefined' ? order.indexer : this.indexer,
       execution: 'close',
     });
   },


### PR DESCRIPTION
# ℹ Overview

Added fetching of missing order properties to `cancelOrder()` similar to what `placeOrder()` does

### 📝 Related Issues
https://github.com/algodex/algodex-sdk/issues/206

