### PR TITLE
🐛 Updated boolean check to be greater than asset decimal precision and not 0

### DIFF
--- a/lib/order/structure/getMakerTakerOrders.js
+++ b/lib/order/structure/getMakerTakerOrders.js
@@ -82,7 +82,7 @@ async function getMakerTakerOrders(api, order) {
   const assetPrecision = 1/(10 ** order.asset.decimals);
 
   // Add Maker Order to response if overflow
-  if (remainder > assetPrecision) {
+  if (remainder >= assetPrecision) {
     orders.push(
         await withMakerTxns(api, await compile({
           ...order,

--- a/lib/order/structure/getMakerTakerOrders.js
+++ b/lib/order/structure/getMakerTakerOrders.js
@@ -79,9 +79,10 @@ async function getMakerTakerOrders(api, order) {
    * @type {Number}
    */
   const remainder = orders.reduce((result, o) => result -= fromBaseUnits(o.contract.amount), order.amount);
+  const assetPrecision = 1/(10 ** order.asset.decimals);
 
   // Add Maker Order to response if overflow
-  if (remainder > 0) {
+  if (remainder > assetPrecision) {
     orders.push(
         await withMakerTxns(api, await compile({
           ...order,

--- a/lib/order/txns/buy/makePlaceAlgoTxns.js
+++ b/lib/order/txns/buy/makePlaceAlgoTxns.js
@@ -85,6 +85,11 @@ async function makePlaceAlgoTxns(
   if (order.execution !== 'maker') {
     throw new Error('Must be maker only mode!');
   }
+
+  if (order.contract?.amount === 0) {
+    throw new Error('Cannot place a maker order with a 0 Amount');
+  }
+
   logger.info({order: {price: order.price, amount: order.amount, total: order.total}, optIn}, 'Make Place Algo Txns');
   // TODO: Note that contains the creator address and the current operation.
   const _note = undefined;

--- a/lib/order/txns/sell/makePlaceAssetTxns.js
+++ b/lib/order/txns/sell/makePlaceAssetTxns.js
@@ -42,6 +42,10 @@ async function makePlaceAssetTxns(
     throw new TypeError('Order must have a valid contract state with an entry!');
   }
 
+  if (order.contract?.amount === 0) {
+    throw new Error('Cannot place a maker order with a 0 Amount');
+  }
+
   if (order.execution !== 'maker') {
     throw new Error('Must be maker only mode!');
   }


### PR DESCRIPTION
# ℹ Overview

Remainder now has to be greater than the decimal precision of an asset in an order.

