### PR TITLE
🐛Fix: addresses edge cases with cutORder closeOut

### DIFF
--- a/lib/order/txns/buy/makeExecuteAlgoTxns.js
+++ b/lib/order/txns/buy/makeExecuteAlgoTxns.js
@@ -59,6 +59,8 @@ async function makeExecuteAlgoTxns(
   }
 
   const _suggestedParams = await teal.getTransactionParams(order.client, order?.contract?.params, true);
+  _suggestedParams.flatFee = false;
+  _suggestedParams.fee = 0;
 
 
   //   if (!exists) { // ToDo: I don't think we need to check if taker's exist
@@ -146,6 +148,7 @@ async function makeExecuteAlgoTxns(
 
     },
   ];
+  _outerTxns[2].unsignedTxn.flatFee = true;
 
   const refundFees = 0.002 * 1000000;
   if (typeof closeRemainderTo === 'undefined') {


### PR DESCRIPTION
# ℹ Overview
After a lot of trial and error and deeply studying the way v1 builds transaction groups I have found that these subtle changes related to the `fee` and `flatFee` address the edgecases related to a cutOrder closeout. All transactions in the group need to be `flatFee` false except for `TXN 2` which needs to be `flatFee=true`. In addition, setting the `fee=0` is also needed as this defaults the fee to `1000`. 

### 📝 Related Issues
#258 

