### PR TITLE
Issue 265 feature add market 20% threshold for market order pricing

### DIFF
--- a/lib/order/structure/getMakerTakerOrders.js
+++ b/lib/order/structure/getMakerTakerOrders.js
@@ -78,7 +78,8 @@ async function getMakerTakerOrders(api, order) {
    * Remainder of the current order
    * @type {Number}
    */
-  let remainder = orders.reduce((result, o) => result -= fromBaseUnits(o.contract.amount), order.amount);
+  const remainder = orders.reduce((result, o) => result -= fromBaseUnits(o.contract.amount, order.asset.decimals), order.amount);
+
   const assetPrecision = 1/(10 ** order.asset.decimals);
 
   if (orders.length > 0 && orders[0].type === 'sell') {

--- a/lib/order/structure/getMakerTakerOrders.js
+++ b/lib/order/structure/getMakerTakerOrders.js
@@ -85,8 +85,6 @@ async function getMakerTakerOrders(api, order) {
   if (orders.length > 0 && orders[0].type === 'sell') {
     if (remainder * order.price < 0.500001) {
       return orders; // This is to prevent placing a maker buy order with a total amount less than 0.5 algo
-    } else {
-      remainder = remainder - 0.02;
     }
   }
   // Add Maker Order to response if overflow

--- a/lib/order/structure/structure.js
+++ b/lib/order/structure/structure.js
@@ -49,6 +49,8 @@ async function structure(api, order) {
   if (!(order?.client instanceof algosdk.Algodv2)) throw new TypeError('Must have valid algod client!!!');
 
   let orders;
+  const tolerance = 0.2;
+  const marketPrice = order.type === 'sell' ? order.price * (1- tolerance) : order.price * (1 + tolerance);
 
   switch (order.execution) {
     // Place Order into Orderbook, single order with outerTxns
@@ -57,9 +59,13 @@ async function structure(api, order) {
       break;
     // Execute Orders in the Orderbook,
     case 'taker':
+      orders = await getTakerOrders(api, order);
+      break;
     case 'market':
       // TODO: Support Market Orders in getTakerOrders
-      orders = await getTakerOrders(api, order);
+
+      // Selling at market price we agree to sell at any price up to 20% below the current market price and vise versa for buy orders
+      orders = await getTakerOrders(api, {...order, price: marketPrice});
       break;
     case 'execute':
       orders = [await withExecuteTxns(await compile(order))];

--- a/lib/order/structure/taker/getTakerOrderInformation.js
+++ b/lib/order/structure/taker/getTakerOrderInformation.js
@@ -101,7 +101,7 @@ async function getTakerOrderInformation(
 
   const _finalAmountsObj = {
     orderAssetAmount: _order.contract.amount,
-    orderAlgoAmount: _order.contract.amount * order.price,
+    orderAlgoAmount: _order.contract.total,
     walletAlgoAmount: _walletAlgoAmount,
     walletAssetAmount: _walletAssetAmount,
   };


### PR DESCRIPTION
# ℹ Overview

Added market pricing to the market section of the switch statement of `structure.js`
The only other thing of note was changing the `orderAlgoAmount` to reflect the user inputted total instead of calculating it as` order.price * order.amount`. This is a subtle but significant necessity for market orders because we want to ensure that the total amount of Algo being sent is ALWAYS what the user submits on the GUI. In the case of a potential price increase for a market order, we lower the amount of ASA, we never increase the algo being sent/received. This is the same behavior as in V1. 

### 📝 Related Issues
#265 


