### PR TITLE
280 teal escrow pay closeout with opt in

### DIFF
--- a/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
@@ -33,7 +33,7 @@ describe('Algo ESCROW ORDER BOOK', () => {
       // set up the Algo Escrow to be executed
         const result = await placeAlgoOrderTest.runTest(config, asaAmount, price);
         expect(result).toBeTruthy();
-        await timeout(12000);
+        await timeout(4000);
       },
       JEST_MINUTE_TIMEOUT,
   );
@@ -41,6 +41,7 @@ describe('Algo ESCROW ORDER BOOK', () => {
   test(
       'Partially execute algo escrow order (no opt-in txn)',
       async () => {
+        await timeout(4000);
         const result = await executeAlgoEscrowOrderTest.runPartialExecTest(
             config,
             executorAmount,

--- a/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
@@ -33,7 +33,7 @@ describe('Algo ESCROW ORDER BOOK', () => {
       // set up the Algo Escrow to be executed
         const result = await placeAlgoOrderTest.runTest(config, asaAmount, price);
         expect(result).toBeTruthy();
-        await timeout(4000);
+        await timeout(12000);
       },
       JEST_MINUTE_TIMEOUT,
   );

--- a/lib/order/__tests__/TealAsaEscrowPayCloseoutWithOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayCloseoutWithOptInTxn.spec.js
@@ -1,117 +1,71 @@
-it('should fix these tests', ()=>{
+it('should fix these tests', () => {
   const isBroken = true;
   expect(isBroken).toEqual(true);
 });
-// const testHelper = require('./setup.js');
-// const transactionGenerator = require('../generate_transaction_types.js');
-// const createAppTest = require('./teal_tests/createAppTest.js');
-// const deleteAppTest = require('./teal_tests/deleteAppTest.js');
-// const placeOrderTest = require('./teal_tests/placeAlgoEscrowOrder.js');
-// const executeAlgoOrderTest = require('./teal_tests/executeAlgoEscrowOrder.js');
-// const executeAsaOrderTest = require('./teal_tests/executeASAEscrowOrder.js');
-// const placeASAOrderTest = require('./teal_tests/placeASAEscrowOrder.js');
-// const closeOrderTest = require('./teal_tests/closeAlgoEscrowOrder.js');
-// const closeASAOrderTest = require('./teal_tests/closeASAEscrowOrder.js');
-// const algosdk = require('algosdk');
+const accountSetup = require('./accountSetup.js');
+const placeASAOrderTest = require('./teal_tests/placeASAEscrowOrder.js');
+const { timeout } = require('../../teal/utils');
+const closeASAOrderTest = require('./teal_tests/closeASAEscrowOrder.js');
+const executeASAEscrowOrderTest = require('./teal_tests/executeASAEscrowOrder');
+const JEST_MINUTE_TIMEOUT = 60 * 10000;
+const config = require('./TealConfig');
+const takerAccountCleanup = require('./takerAccountCleanup');
+
 //
-//
-// const AlgodexApi = require('../algodex_api.js');
-// const constants = require('../constants.js');
-// const JEST_MINUTE_TIMEOUT = 60 * 1000;
-//
-// const config = {
-//   appId: -1,
-//   creatorAccount: testHelper.getRandomAccount(),
-//   executorAccount: testHelper.getRandomAccount(),
-//   openAccount: testHelper.getOpenAccount(),
-//   maliciousAccount: testHelper.getRandomAccount(),
-//   client: testHelper.getLocalClient(),
-//   assetId: 66711302,
-// };
-//
-// console.log('DEBUG_SMART_CONTRACT_SOURCE is: ' + constants.DEBUG_SMART_CONTRACT_SOURCE);
-//
-// const textEncoder = new TextEncoder();
-//
-// // TODO: The negative tests need to be implemented. The commented ones out are examples but will not work with
-// // this transaction type.
-// const negTests = [
-//   /* {txnNum: 0, field: 'from', val: algosdk.decodeAddress(config.maliciousAccount.addr) },
-//    {txnNum: 0, field: 'appArgs', innerNum: 0, val: textEncoder.encode('execute') },
-//    {txnNum: 0, field: 'appIndex', configKeyForVal: 'fakeAppId' },
-//    {txnNum: 0, field: 'appOnComplete', val: 0},
-//    {txnNum: 1, field: 'from', val: algosdk.decodeAddress(config.maliciousAccount.addr) },
-//    {txnNum: 1, field: 'closeRemainderTo', val: algosdk.decodeAddress(config.maliciousAccount.addr) },
-//    {txnNum: 1, negTxn: {
-//             unsignedTxnPromise: transactionGenerator.getAssetSendTxn(config.client, config.maliciousAccount.addr, config.maliciousAccount.addr,
-//               1000, config.assetId, false),
-//             senderAcct: config.maliciousAccount
-//             }
-//     },
-//    {txnNum: 2, field: 'from', txnKeyForVal: 'from', txnNumForVal: 1}, //set to from escrow
-//    {txnNum: 2, field: 'to', val: algosdk.decodeAddress(config.maliciousAccount.addr)},
-//    {txnNum: 2, negTxn: {
-//             unsignedTxnPromise: transactionGenerator.getPayTxn(config.client,
-//             config.maliciousAccount.addr, config.maliciousAccount.addr,
-//                 1000, false),
-//             senderAcct: config.maliciousAccount
-//         }
-//     },*/
-//
-// ];
-//
-//
-// describe('ASA ESCROW ORDER BOOK', () => {
-//   test('Create asa escrow order book', async () => {
-//     config.creatorAccount = testHelper.getRandomAccount();
-//     config.executorAccount = testHelper.getRandomAccount();
-//     config.maliciousAccount = testHelper.getRandomAccount();
-//     config.appId = await createAppTest.runTest(config, false, false);
-//     global.ASA_ESCROW_APP_ID = config.appId;
-//     expect(config.appId).toBeGreaterThan(0);
-//   }, JEST_MINUTE_TIMEOUT);
-//
-//   test('Place asa escrow order', async () => {
-//     const asaAmount = 400000;
-//     const price = 1.25;
-//     const result = await placeASAOrderTest.runTest(config, asaAmount, price);
-//     expect(result).toBeTruthy();
-//   }, JEST_MINUTE_TIMEOUT);
-//
-//
-//   negTests.map( (negTestTxnConfig) => {
-//     const testName = `Negative algo full execution order test: txnNum: ${negTestTxnConfig.txnNum} field: ${negTestTxnConfig.field} val: ${negTestTxnConfig.val}`;
-//     test(testName, async () => {
-//       if (negTestTxnConfig.negTxn) {
-//         negTestTxnConfig.negTxn.unsignedTxn = await negTestTxnConfig.negTxn.unsignedTxnPromise;
-//       }
-//       const outerTxns = await executeAlgoOrderTest.runFullExecTest(config, true);
-//       outerTxns.map( (txn) => {
-//         const unsignedTxn = txn.unsignedTxn;
-//         // console.log({unsignedTxn});
-//       });
-//       const result = await testHelper.runNegativeTest(config, config.client, outerTxns, negTestTxnConfig);
-//       expect(result).toBeTruthy();
-//     }, JEST_MINUTE_TIMEOUT);
-//   });
-//
-//   test('Fully execute asa escrow order (with asa opt-in)', async () => {
-//     let asaBalance = await testHelper.getAssetBalance(config.executorAccount.addr, config.assetId);
-//     expect(asaBalance).toBeNull();
-//
-//     const price = 1.25;
-//     // The execution will cause it to be opted in
-//     const result = await executeAsaOrderTest.runFullExecTest(config, price);
-//     expect(result).toBeTruthy();
-//
-//     asaBalance = await testHelper.getAssetBalance(config.executorAccount.addr, config.assetId);
-//     expect(asaBalance).toBeGreaterThan(0);
-//   }, JEST_MINUTE_TIMEOUT);
-//
-//
-//   test('Delete asa escrow order book', async () => {
-//     const result = await deleteAppTest.runTest(config);
-//     expect(result).toBeTruthy();
-//   }, JEST_MINUTE_TIMEOUT);
-// });
-//
+describe('ASA ESCROW ORDER BOOK', () => {
+  const asaAmount = 0.4;
+  const price = 1.25;
+  const executorAmount = 0.41;
+
+  beforeAll(async () => {
+    await accountSetup(config, 'sell', false, true);// Since we're testing withOptIn on the executor account we pass false for optIn in account setup 
+    await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
+  }, JEST_MINUTE_TIMEOUT);
+
+  afterAll(async () => {
+    await timeout(4000);
+    await takerAccountCleanup(config, 'sell', executorAmount, true);
+  }, JEST_MINUTE_TIMEOUT);
+
+  test(
+    'Place asa escrow order',
+    async () => {
+      const result = await placeASAOrderTest.runTest(config, asaAmount, price);
+      expect(result).toBeTruthy();
+      await timeout(12000);
+    },
+    JEST_MINUTE_TIMEOUT
+  );
+
+  test(
+    'Closeout execute asa escrow order with Optin',
+    async () => {
+      const result = await executeASAEscrowOrderTest.runPartialExecTest(
+        config,
+        executorAmount,
+        price
+      );
+      expect(result).toBeTruthy();
+      await timeout(4000);
+    },
+    JEST_MINUTE_TIMEOUT
+  );
+
+  // test(
+  //   'Close asa escrow order',
+  //   async () => {
+  //     const result = await closeASAOrderTest.runTest(
+  //       config,
+  //       price,
+  //       asaAmount - executorAmount
+  //     );
+  //     expect(result).toBeTruthy();
+  //   },
+  //   JEST_MINUTE_TIMEOUT
+  // );
+
+  // test('Delete asa escrow order book', async () => {
+  //   const result = await deleteAppTest.runTest(config);
+  //   expect(result).toBeTruthy();
+  // }, JEST_MINUTE_TIMEOUT);
+});

--- a/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
@@ -41,6 +41,8 @@ describe('ASA ESCROW ORDER BOOK', () => {
   test(
     'Partially execute asa escrow order (no opt-in txn)',
     async () => {
+      await timeout(4000);
+
       const result = await executeASAEscrowOrderTest.runPartialExecTest(
         config,
         executorAmount,

--- a/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
@@ -7,7 +7,7 @@ const placeASAOrderTest = require('./teal_tests/placeASAEscrowOrder.js');
 const { timeout } = require('../../teal/utils');
 const closeASAOrderTest = require('./teal_tests/closeASAEscrowOrder.js');
 const executeASAEscrowOrderTest = require('./teal_tests/executeASAEscrowOrder');
-const JEST_MINUTE_TIMEOUT = 60 * 1000;
+const JEST_MINUTE_TIMEOUT = 60 * 10000;
 const config = require('./TealConfig');
 const takerAccountCleanup = require('./takerAccountCleanup');
 
@@ -33,7 +33,7 @@ describe('ASA ESCROW ORDER BOOK', () => {
     async () => {
       const result = await placeASAOrderTest.runTest(config, asaAmount, price);
       expect(result).toBeTruthy();
-      await timeout(4000);
+      await timeout(12000);
     },
     JEST_MINUTE_TIMEOUT
   );

--- a/lib/order/__tests__/TealAsaEscrowPayPartialWithOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayPartialWithOptInTxn.spec.js
@@ -40,6 +40,7 @@ describe('ASA ESCROW ORDER BOOK', () => {
   test(
     'Partially execute asa escrow order with Optin',
     async () => {
+      await timeout(4000);
       const result = await executeASAEscrowOrderTest.runPartialExecTest(
         config,
         executorAmount,

--- a/lib/order/__tests__/takerAccountCleanup.js
+++ b/lib/order/__tests__/takerAccountCleanup.js
@@ -28,7 +28,7 @@ async function takerAccountCleanup(config, type, executorAmount, closeOut) {
       2000000 - formattedExecutorAmount, //initial 2 units less
       assetId
     ); // transfer back ASA
-    await transferFunds(client, creatorAccount, openAccount, 1500000); //transfer original algo
+    await transferFunds(client, creatorAccount, openAccount, 1250000); //transfer original algo
 
     await transferASA(
       client,
@@ -37,7 +37,7 @@ async function takerAccountCleanup(config, type, executorAmount, closeOut) {
       formattedExecutorAmount-10000, //account for potential rounding errors 
       assetId
     );
-    await transferFunds(client, executorAccount, openAccount, 1500000); //transfer original algo
+    await transferFunds(client, executorAccount, openAccount, 1250000); //transfer original algo
   }
 
   if(type === 'buy'){

--- a/lib/order/__tests__/teal_tests/executeASAEscrowOrder.js
+++ b/lib/order/__tests__/teal_tests/executeASAEscrowOrder.js
@@ -4,8 +4,10 @@ const transactionGenerator = require('../GenerateTransactionTypes');
 const algosdk = require('algosdk');
 const signer = require('../../../wallet/signers/AlgoSDK');
 const _sendTransactions = require('./sendTransactions');
-
+const withExecuteTxns = require('../../structure/taker/withExecuteTxns')
+const compile = require('../../compile/compile')
 const PRINT_TXNS = 0;
+
 
 const Test = {
   runPartialExecTest: async function (
@@ -52,6 +54,112 @@ const Test = {
     }
     const signedTxns = await signer(
       executePartialASAEscrowOrder,
+      config.executorAccount.sk
+    );
+
+    const confirmation = await _sendTransactions(client, signedTxns);
+
+    return true;
+  },
+  runFullExecTest: async function (
+    config,
+    price,
+    returnOuterTransactions = false
+  ) {
+    console.log('STARTING executeASAEscrowOrder full test');
+    const client = config.client;
+    const executorAccount = config.executorAccount;
+    const creatorAccount = config.creatorAccount;
+    const appId = config.appId;
+    const assetId = config.assetId;
+
+    const lsig = await testHelper.getOrderLsig(
+      client,
+      creatorAccount,
+      price,
+      config.assetId,
+      true
+    );
+
+    const asaAmountReceiving = await testHelper.getAssetBalance(
+      lsig.address(),
+      assetId
+    );
+
+    let algoAmountSending = asaAmountReceiving * price;
+
+    if (Math.floor(algoAmountSending) != algoAmountSending) {
+      algoAmountSending = Math.floor(algoAmountSending) + 1; // give slightly better deal to maker
+    }
+
+    console.log({ asaAmountReceiving }, { algoAmountSending });
+    const outerTxns = await transactionGenerator.getExecuteASAEscrowOrderTxns(
+      client,
+      config.executorAccount,
+      creatorAccount,
+      algoAmountSending,
+      asaAmountReceiving,
+      price,
+      assetId,
+      appId,
+      true
+    );
+
+    if (returnOuterTransactions) {
+      return outerTxns;
+    }
+    const signedTxns = testHelper.groupAndSignTransactions(outerTxns);
+
+    await testHelper.sendAndCheckConfirmed(client, signedTxns);
+
+    return true;
+  },
+  runCloseOutExecutionTest: async function (
+    config,
+    takerAmount,
+    price,
+    returnOuterTransactions = false
+  ) {
+    console.log('STARTING runPartialExecTest');
+    const client = config.client;
+
+    const creatorAccount = config.executorAccount.addr;
+    const wallet = {
+      type: 'sdk',
+      address: config.executorAccount.addr,
+      connector: {
+        ...config.connector,
+        sk: config.creatorAccount.sk, //Just in case we want to test signing and sending from the api and not from the tests.
+        connected: true,
+      },
+      // mnemonic: config.creatorAccount.sk,
+    };
+
+    const order = {
+      asset: {
+        id: config.assetId,
+        decimals: 6,
+      },
+      address: config.executorAccount.addr,
+      price: price,
+      amount: takerAmount,
+      total: price * takerAmount,
+      type: 'buy',
+      client: config.client,
+      execution: 'execute',
+      wallet: wallet,
+      appId: 22045522,
+      version: 6,
+    };
+
+    const executeCloseOutASAEscrowOrder =
+       await withExecuteTxns(await compile(order), true)
+
+    if (returnOuterTransactions) {
+      return outerTxns;
+    }
+    const signedTxns = await signer(
+      executeCloseOutASAEscrowOrder,
       config.executorAccount.sk
     );
 


### PR DESCRIPTION
# ℹ Overview

Tests passing for `teal escrow pay with optIn` but I'm starting to rethink the approach of waiting a hard coded amount of time between placing and executing orders from the orderbook. Every once in a while a taker test will fail on account of the orderbook not showing the executable order fast enough. The SDK allows for the ability to attach an orderbook to the `asset:{}` property of an Order. A better implementation would be to fetch and check the orderbook and attach to the asset property  before running the taker test, that way we guarantee the state of the orderbook. 

### 📝 Related Issues

#280 


