### PR TITLE
✅: 284 fetch the orderbook and check the state before passing order into taker execution tests

### DIFF
--- a/lib/order/__tests__/GenerateTransactionTypes.js
+++ b/lib/order/__tests__/GenerateTransactionTypes.js
@@ -3,6 +3,7 @@ const withPlaceAlgoTxns = require('../txns/buy/withPlaceAlgoTxns');
 const withCloseAssetTxns = require('../txns/close/withCloseAssetTxns');
 const withCloseAlgoTxns = require('../txns/close/withCloseAlgoTxns');
 const getTakerOrders = require('../structure/getTakerOrders');
+const { timeout } = require('../../teal/utils');
 
 const compile = require('../compile/compile');
 const AlgodexApi = require('../../AlgodexApi');
@@ -108,6 +109,28 @@ const TransactionGenerator = {
   getTakerOrderTxns: async function (order) {
     algodexApi.setWallet(order.wallet);
 
+    let _orderbook = await algodexApi.http.dexd.fetchAssetOrders(order.asset.id)
+
+    try {
+      while (
+        Object.values(_orderbook).reduce((a, b) => {
+          return a.concat(b); // need to put inside the while statement so the expression re runs every time _orderbook changes
+        }, []).length === 0
+      ) {
+        await timeout(4000);
+        _orderbook = await algodexApi.http.dexd.fetchAssetOrders(
+          order.asset.id
+        );
+      }
+    } catch (e) {
+      throw e;
+    }
+
+    let orderbook = algodexApi.http.dexd.mapToAllEscrowOrders({
+      buy: _orderbook.buyASAOrdersInEscrow,
+      sell: _orderbook.sellASAOrdersInEscrow,
+    });
+
     return await getTakerOrders(algodexApi, {
       ...order,
       appId:
@@ -116,6 +139,10 @@ const TransactionGenerator = {
           : order.appId,
       version: 6,
       indexer: algodexApi.indexer,
+      asset: {
+        ...order.asset,
+        orderbook
+      },
       wallet: {
         ...order.wallet,
         ...(await algodexApi.http.indexer.fetchAccountInfo(order.wallet)),

--- a/lib/order/__tests__/TealAlgoEscrowPayCloseout.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPayCloseout.spec.js
@@ -33,7 +33,6 @@ describe('Algo ESCROW ORDER BOOK', () => {
       // set up the Algo Escrow to be executed
         const result = await placeAlgoOrderTest.runTest(config, asaAmount, price);
         expect(result).toBeTruthy();
-        await timeout(4000);
       },
       JEST_MINUTE_TIMEOUT,
   );

--- a/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
@@ -33,7 +33,6 @@ describe('Algo ESCROW ORDER BOOK', () => {
       // set up the Algo Escrow to be executed
         const result = await placeAlgoOrderTest.runTest(config, asaAmount, price);
         expect(result).toBeTruthy();
-        await timeout(4000);
       },
       JEST_MINUTE_TIMEOUT,
   );
@@ -41,7 +40,6 @@ describe('Algo ESCROW ORDER BOOK', () => {
   test(
       'Partially execute algo escrow order (no opt-in txn)',
       async () => {
-        await timeout(4000);
         const result = await executeAlgoEscrowOrderTest.runPartialExecTest(
             config,
             executorAmount,

--- a/lib/order/__tests__/TealAsaEscrowCancel.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowCancel.spec.js
@@ -59,7 +59,7 @@ const JEST_MINUTE_TIMEOUT = 60 * 1000;
 // ];
 //
 //
-describe.skip('ASA ESCROW ORDER BOOK', () => {
+describe('ASA ESCROW ORDER BOOK', () => {
   const price = 1.2;
   const amount = 0.8;
 
@@ -70,42 +70,6 @@ describe.skip('ASA ESCROW ORDER BOOK', () => {
     await timeout(7000);
   }, JEST_MINUTE_TIMEOUT * 10);
 
-  // Delete App
-  // afterAll(async () => {
-  //   await deleteApplication(config.client, config.creatorAccount, config.appId);
-  //   await closeAccount(
-  //     config.client,
-  //     config.creatorAccount,
-  //     config.openAccount
-  //   );
-  //   await closeAccount(
-  //     config.client,
-  //     config.executorAccount,
-  //     config.openAccount
-  //   );
-  //   await closeAccount(
-  //     config.client,
-  //     config.maliciousAccount,
-  //     config.openAccount
-  //   );
-  // }, JEST_MINUTE_TIMEOUT);
-
-  // negTests.map( (negTestTxnConfig) => {
-  //   const testName = `Negative algo full execution order test: txnNum: ${negTestTxnConfig.txnNum} field: ${negTestTxnConfig.field} val: ${negTestTxnConfig.val}`;
-  //   test(testName, async () => {
-  //     if (negTestTxnConfig.negTxn) {
-  //       negTestTxnConfig.negTxn.unsignedTxn = await negTestTxnConfig.negTxn.unsignedTxnPromise;
-  //     }
-  //     const outerTxns = await executeAlgoOrderTest.runFullExecTest(config, true);
-  //     outerTxns.map( (txn) => {
-  //       const unsignedTxn = txn.unsignedTxn;
-  //       // console.log({unsignedTxn});
-  //     });
-  //     const result = await testHelper.runNegativeTest(config, config.client, outerTxns, negTestTxnConfig);
-  //     expect(result).toBeTruthy();
-  //   }, JEST_MINUTE_TIMEOUT);
-  // });
-
   test(
     'Close asa escrow order',
     async () => {
@@ -115,8 +79,4 @@ describe.skip('ASA ESCROW ORDER BOOK', () => {
     JEST_MINUTE_TIMEOUT * 2
   );
 
-  // test('Delete asa escrow order book', async () => {
-  //   const result = await deleteAppTest.runTest(config);
-  //   expect(result).toBeTruthy();
-  // }, JEST_MINUTE_TIMEOUT);
 });

--- a/lib/order/__tests__/TealAsaEscrowPayCloseoutWithOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayCloseoutWithOptInTxn.spec.js
@@ -32,7 +32,6 @@ describe('ASA ESCROW ORDER BOOK', () => {
     async () => {
       const result = await placeASAOrderTest.runTest(config, asaAmount, price);
       expect(result).toBeTruthy();
-      await timeout(12000);
     },
     JEST_MINUTE_TIMEOUT
   );
@@ -46,26 +45,8 @@ describe('ASA ESCROW ORDER BOOK', () => {
         price
       );
       expect(result).toBeTruthy();
-      await timeout(4000);
     },
     JEST_MINUTE_TIMEOUT
   );
 
-  // test(
-  //   'Close asa escrow order',
-  //   async () => {
-  //     const result = await closeASAOrderTest.runTest(
-  //       config,
-  //       price,
-  //       asaAmount - executorAmount
-  //     );
-  //     expect(result).toBeTruthy();
-  //   },
-  //   JEST_MINUTE_TIMEOUT
-  // );
-
-  // test('Delete asa escrow order book', async () => {
-  //   const result = await deleteAppTest.runTest(config);
-  //   expect(result).toBeTruthy();
-  // }, JEST_MINUTE_TIMEOUT);
 });

--- a/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
@@ -33,7 +33,6 @@ describe('ASA ESCROW ORDER BOOK', () => {
     async () => {
       const result = await placeASAOrderTest.runTest(config, asaAmount, price);
       expect(result).toBeTruthy();
-      await timeout(12000);
     },
     JEST_MINUTE_TIMEOUT
   );
@@ -41,8 +40,6 @@ describe('ASA ESCROW ORDER BOOK', () => {
   test(
     'Partially execute asa escrow order (no opt-in txn)',
     async () => {
-      await timeout(4000);
-
       const result = await executeASAEscrowOrderTest.runPartialExecTest(
         config,
         executorAmount,
@@ -67,8 +64,4 @@ describe('ASA ESCROW ORDER BOOK', () => {
     JEST_MINUTE_TIMEOUT
   );
 
-  // test('Delete asa escrow order book', async () => {
-  //   const result = await deleteAppTest.runTest(config);
-  //   expect(result).toBeTruthy();
-  // }, JEST_MINUTE_TIMEOUT);
 });

--- a/lib/order/__tests__/TealAsaEscrowPayPartialWithOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayPartialWithOptInTxn.spec.js
@@ -32,7 +32,6 @@ describe('ASA ESCROW ORDER BOOK', () => {
     async () => {
       const result = await placeASAOrderTest.runTest(config, asaAmount, price);
       expect(result).toBeTruthy();
-      await timeout(4000);
     },
     JEST_MINUTE_TIMEOUT
   );
@@ -40,7 +39,6 @@ describe('ASA ESCROW ORDER BOOK', () => {
   test(
     'Partially execute asa escrow order with Optin',
     async () => {
-      await timeout(4000);
       const result = await executeASAEscrowOrderTest.runPartialExecTest(
         config,
         executorAmount,

--- a/lib/order/__tests__/teal_tests/closeAlgoEscrowOrder.js
+++ b/lib/order/__tests__/teal_tests/closeAlgoEscrowOrder.js
@@ -43,14 +43,14 @@ const Test = {
       wallet: wallet,
     };
 
-    const closeASAEscrowOrder =
+    const closeAlgoEscrowOrder =
       await transactionGenerator.getCloseAlgoEscrowOrderTxns(order);
 
     if (returnOuterTransactions) {
       return outerTxns;
     }
     const signedTxns = await signer(
-      [closeASAEscrowOrder],
+      [closeAlgoEscrowOrder],
       config.creatorAccount.sk
     );
 


### PR DESCRIPTION
# ℹ Overview
The `orderbook` is being fetched and its length checked before structuring any taker order. This eliminates race conditions related to the hardcoded `timeouts()`. As a result tests run up to 16 seconds faster and produce consistent results. Read related issue for a more detailed explanation.

Related Issues:
#284 




