### PR TITLE
✨ 290 edit account setup function to take an optional note parameter

### DIFF
--- a/lib/order/__tests__/TealAlgoEscrowCancel.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowCancel.spec.js
@@ -9,9 +9,16 @@ const accountSetup = require('./accountSetup.js');
 describe('Algo ESCROW ORDER BOOK', () => {
   const price = 1.2;
   const amount = 0.8;
+  const note = `
+  Testing: TealAlgoEscrowCancel
+  Open Account: ${config.openAccount.addr}
+  Creator Account: ${config.creatorAccount.addr}
+  
+  Creator Account is buying ${amount} LAMPC at price: ${price} Algo
+`
 
   beforeAll(async () => {
-    await accountSetup(config, 'buy', true); 
+    await accountSetup(config, 'buy', true, false, note); 
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAlgoEscrowPayCloseout.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPayCloseout.spec.js
@@ -17,8 +17,18 @@ describe('Algo ESCROW ORDER BOOK', () => {
   const price = 1.25;
   const executorAmount = 0.4;
 
+  const note = `
+  Testing: TealAlgoEscrowPayCloseout
+  Open Account: ${config.openAccount.addr}
+  Creator Account: ${config.creatorAccount.addr}
+  Executor Account: ${config.executorAccount.addr}
+
+  Creator Account is buying ${asaAmount} LAMPC at price: ${price} Algo
+  Executor Account is selling ${executorAmount} LAMPC 
+`
+
   beforeAll(async () => {
-    await accountSetup(config, 'buy', true, true);
+    await accountSetup(config, 'buy', true, true, note);
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPayPartial.spec.js
@@ -17,8 +17,19 @@ describe('Algo ESCROW ORDER BOOK', () => {
   const price = 1.25;
   const executorAmount = 0.2;
 
+
+  const note = `
+    Testing: TealAlgoEscrowPayPartial
+    Open Account: ${config.openAccount.addr}
+    Creator Account: ${config.creatorAccount.addr}
+    Executor Account: ${config.executorAccount.addr}
+
+    Creator Account is buying ${asaAmount} LAMPC at price: ${price} Algo
+    Executor Account is selling ${executorAmount} LAMPC 
+  `
+
   beforeAll(async () => {
-    await accountSetup(config, 'buy', true, true);
+    await accountSetup(config, 'buy', true, true, note);
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAlgoEscrowPlaceNoOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPlaceNoOptInTxn.spec.js
@@ -15,8 +15,16 @@ const accountCleanup = require('./accountCleanup.js');
 describe('ALGO ESCROW ORDER BOOK (opt in test)', () => {
   const amount = 0.8;
   const price = 1.2;
+
+  const note = `
+  Testing: TealAlgoEscrowPlaceNoOptInTxn
+  Open Account: ${config.openAccount.addr}
+  Creator Account: ${config.creatorAccount.addr}
+
+  Creator Account is buying ${amount} LAMPC at price: ${price} Algo
+`
   beforeAll(async () => {
-    await accountSetup(config, 'buy', true); //optIn in the setUp phase to test sdk no optIn
+    await accountSetup(config, 'buy', true, false, note); //optIn in the setUp phase to test sdk no optIn
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAlgoEscrowPlaceWithOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAlgoEscrowPlaceWithOptInTxn.spec.js
@@ -15,8 +15,17 @@ const accountCleanup = require('./accountCleanup.js');
 describe('ALGO ESCROW ORDER BOOK (opt in test)', () => {
   const amount = 0.8;
   const price = 1.2;
+
+  const note = `
+    Testing: TealAlgoEscrowPlaceWithOptInTxn
+    Open Account: ${config.openAccount.addr}
+    Creator Account: ${config.creatorAccount.addr}
+
+    Creator Account is buying ${amount} LAMPC at price: ${price} Algo
+  `
+
   beforeAll(async () => {
-    await accountSetup(config, 'buy', false);
+    await accountSetup(config, 'buy', false, false, note);
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAsaEscrowPayCloseoutNoOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayCloseoutNoOptInTxn.spec.js
@@ -16,8 +16,18 @@ describe('ASA ESCROW ORDER BOOK', () => {
   const price = 1.25;
   const executorAmount = 0.41;
 
+  const note = `
+    Testing: TealAsaEscrowPayCloseoutNoOptInTxn
+    Open Account: ${config.openAccount.addr}
+    Creator Account: ${config.creatorAccount.addr}
+    Executor Account: ${config.executorAccount.addr}
+
+    Creator Account is selling ${asaAmount} LAMPC at price: ${price} Algo
+    Executor Account is buying ${executorAmount} LAMPC (rounding issue normally will be ${asaAmount})
+  `
+
   beforeAll(async () => {
-    await accountSetup(config, 'sell', true, true);// Since we're testing noOptIn on the executor account we pass true for optIn in account setup 
+    await accountSetup(config, 'sell', true, true, note);// Since we're testing noOptIn on the executor account we pass true for optIn in account setup 
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAsaEscrowPayCloseoutWithOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayCloseoutWithOptInTxn.spec.js
@@ -17,8 +17,18 @@ describe('ASA ESCROW ORDER BOOK', () => {
   const price = 1.25;
   const executorAmount = 0.41;
 
+  const note = `
+    Testing: TealAsaEscrowPayCloseoutWithOptInTxn
+    Open Account: ${config.openAccount.addr}
+    Creator Account: ${config.creatorAccount.addr}
+    Executor Account: ${config.executorAccount.addr}
+
+    Creator Account is selling ${asaAmount} LAMPC at price: ${price} Algo
+    Executor Account is buying ${executorAmount} LAMPC (rounding issue normally will be ${asaAmount})
+  `
+
   beforeAll(async () => {
-    await accountSetup(config, 'sell', false, true);// Since we're testing withOptIn on the executor account we pass false for optIn in account setup 
+    await accountSetup(config, 'sell', false, true, note);// Since we're testing withOptIn on the executor account we pass false for optIn in account setup 
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayPartialNoOptInTxn.spec.js
@@ -17,9 +17,18 @@ describe('ASA ESCROW ORDER BOOK', () => {
   const price = 1.20;
 
   const executorAmount = 0.2;
+  const note = `
+  Testing: TealAsaEscrowPayPartialnoOptInTxn
+  Open Account: ${config.openAccount.addr}
+  Creator Account: ${config.creatorAccount.addr}
+  Executor Account: ${config.executorAccount.addr}
+
+  Creator Account is selling ${asaAmount} LAMPC at price: ${price} Algo
+  Executor Account is buying ${executorAmount} LAMPC 
+`
 
   beforeAll(async () => {
-    await accountSetup(config, 'sell', true, true);
+    await accountSetup(config, 'sell', true, true, note);
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAsaEscrowPayPartialWithOptInTxn.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPayPartialWithOptInTxn.spec.js
@@ -16,9 +16,19 @@ describe('ASA ESCROW ORDER BOOK', () => {
   const asaAmount = 0.4;
   const price = 1.20;
   const executorAmount = 0.2;
+  
+  const note = `
+    Testing: TealAsaEscrowPayPartialWithOptInTxn
+    Open Account: ${config.openAccount.addr}
+    Creator Account: ${config.creatorAccount.addr}
+    Executor Account: ${config.executorAccount.addr}
+
+    Creator Account is selling ${asaAmount} LAMPC at price: ${price} Algo
+    Executor Account is buying ${executorAmount} LAMPC 
+  `
 
   beforeAll(async () => {
-    await accountSetup(config, 'sell', false, true);// Since we're testing withOptIn on the executor account we pass false for optIn in account setup 
+    await accountSetup(config, 'sell', false, true, note);// Since we're testing withOptIn on the executor account we pass false for optIn in account setup 
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 

--- a/lib/order/__tests__/TealAsaEscrowPlace.spec.js
+++ b/lib/order/__tests__/TealAsaEscrowPlace.spec.js
@@ -52,8 +52,17 @@ describe('ASA ESCROW ORDER BOOK', () => {
   function timeout(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
+  const asaAmount = 0.4;
+  const price = 1.25;
+
+  const note = `
+    Testing: TealAsaEscrowPlace
+    Open Account: ${config.openAccount.addr}
+    Creator Account: ${config.creatorAccount.addr}
+    Creator Account is selling ${asaAmount} LAMPC at price: ${price} Algo
+  `
   beforeAll(async () => {
-    await accountSetup(config, 'sell', true);
+    await accountSetup(config, 'sell', true, false, note);
     await timeout(7000); // Eliminates race condition where future indexer calls occur before setUp step fully propogates but after it succeeds
   }, JEST_MINUTE_TIMEOUT);
 
@@ -63,8 +72,7 @@ describe('ASA ESCROW ORDER BOOK', () => {
     await accountCleanup(config, 'sell', true);
   }, JEST_MINUTE_TIMEOUT);
 
-  const asaAmount = 0.4;
-  const price = 1.25;
+
 
   test(
     'Place asa escrow order',
@@ -77,24 +85,7 @@ describe('ASA ESCROW ORDER BOOK', () => {
     },
     JEST_MINUTE_TIMEOUT
   );
-  //
-  //   negTests.map( (negTestTxnConfig) => {
-  //     const testName = `Negative algo full execution order test: txnNum: ${negTestTxnConfig.txnNum} field: ${negTestTxnConfig.field} val: ${negTestTxnConfig.val}`;
-  //     test(testName, async () => {
-  //       if (negTestTxnConfig.negTxn) {
-  //         negTestTxnConfig.negTxn.unsignedTxn = await negTestTxnConfig.negTxn.unsignedTxnPromise;
-  //       }
-  //       const outerTxns = await executeAlgoOrderTest.runFullExecTest(config, true);
-  //       outerTxns.map( (txn) => {
-  //         const unsignedTxn = txn.unsignedTxn;
-  //         // console.log({unsignedTxn});
-  //       });
-  //       const result = await testHelper.runNegativeTest(config, config.client, outerTxns, negTestTxnConfig);
-  //       expect(result).toBeTruthy();
-  //     }, JEST_MINUTE_TIMEOUT);
-  //   });
-  //
-  //
+
   test(
     'Close asa escrow order',
     async () => {
@@ -105,13 +96,6 @@ describe('ASA ESCROW ORDER BOOK', () => {
     JEST_MINUTE_TIMEOUT
   );
 
-  // test(
-  //   'Delete asa escrow order book',
-  //   async () => {
-  //     const result = await deleteAppTest.runTest(config);
-  //     expect(result).toBeTruthy();
-  //   },
-  //   JEST_MINUTE_TIMEOUT
-  // );
+
 });
 //

--- a/lib/order/__tests__/accountSetup.js
+++ b/lib/order/__tests__/accountSetup.js
@@ -4,6 +4,8 @@ const AlgodexApi = require('../../AlgodexApi');
 const apiConfig = require('../../../config.json');
 const initAccounts = require('../../teal/test/initAccounts');
 const initExecutor = require('../../teal/test/initExecutor');
+const enc = require('../../utils/encoder');
+
 
 const logger = require('../../logger');
 
@@ -12,45 +14,29 @@ const logger = require('../../logger');
  * @param {TestConfig} config Test Configuration
  * @param {'buy'|'sell'} type Type of Order
  * @param {boolean} [optIn] Opt In
- * @param {boolean} [newCreator] create new creator account
+ * @param {boolean} [executor] Parameter for whether or not to set up an executor account to test taker orders
+ * @param {boolean} [note] information related to the test to be included in the note field 
+ * 
  * @return {Promise<any>}
  */
-async function accountSetup(config, type, optIn = false, executor) {
+async function accountSetup(config, type, optIn = false, executor, note) {
   logger.info({ type, optIn, executor }, `order.test.beforeAll()`);
   if (typeof type !== 'string' || !['buy', 'sell'].includes(type)) {
     throw new TypeError('Must have valid type!');
   }
+
+  const encodedNote = typeof note !== 'undefined' ? enc.encode(note) : undefined
 
   // Initalize API Client
   // await config.init(AlgodexApi, [apiConfig]);
   const api = new AlgodexApi(apiConfig);
 
   // Initialize Accounts and Configuration
-  await initAccounts(config, type, optIn);
+  await initAccounts(config, type, optIn, encodedNote);
   if (executor) {
-    await initExecutor(config, type, optIn);
+    await initExecutor(config, type, optIn, encodedNote);
 
   }
-  // const {client, creatorAccount} = config;
-  // const createTxn = await txns.makeApplicationCreateTxn(
-  //     client,
-  //     type,
-  //     creatorAccount,
-  //     config.suggestedParams,
-  // );
-  // const txId = createTxn.txID().toString();
-
-  // const signedTxn = createTxn.signTxn(creatorAccount.sk);
-
-  // await client.sendRawTransaction(signedTxn).do();
-
-  // // Wait for confirmation
-  // await algosdk.waitForConfirmation(client, txId, 10);
-
-  // // display results
-  // const transactionResponse = await client.pendingTransactionInformation(txId).do();
-
-  // config.setAppIndex(transactionResponse['application-index']);
 }
 
 module.exports = accountSetup;

--- a/lib/teal/test/initAccounts.js
+++ b/lib/teal/test/initAccounts.js
@@ -34,7 +34,7 @@ const algodexApi = new AlgodexApi(tesnet);
  * @return {Promise<void>}
  */
 
-async function initAccounts(config, type, optIn = false) {
+async function initAccounts(config, type, optIn = false, note) {
 
   // If we are overriding the default creator account
 
@@ -47,29 +47,20 @@ async function initAccounts(config, type, optIn = false) {
     assetId,
   } = config;
 
-  await transferFunds(client, openAccount, creatorAccount, 2000000);
+  await transferFunds(client, openAccount, creatorAccount, 2000000, note);
 
   if (type === 'sell') {
     //escrowPlaceOrder
-    await transferASA(client, creatorAccount, creatorAccount, 0, assetId); // opt in transaction
-    await transferASA(client, openAccount, creatorAccount, 2000000, assetId); // testASA
+    await transferASA(client, creatorAccount, creatorAccount, 0, assetId, note); // opt in transaction
+    await transferASA(client, openAccount, creatorAccount, 2000000, assetId, note); // testASA
   }
 
   if (type === 'buy') {
     // await transferFunds(client, openAccount, creatorAccount, 5000000); //enough funds to facilitate an escrow place
     if (optIn) {
-      await transferASA(client, creatorAccount, creatorAccount, 0, assetId); // opt in transaction
+      await transferASA(client, creatorAccount, creatorAccount, 0, assetId, note); // opt in transaction
     }
   }
-
-  // if (optIn) {
-  //   await transferASA(client, executorAccount, executorAccount, 0, config.assetIndex); // opt in transaction
-  //   await transferASA(client, openAccount, executorAccount, 2000000, config.assetIndex); // 5 algos
-  // }
-
-  // await transferFunds(client, openAccount, maliciousAccount, 5000000); // 5 algos
-  // await transferASA(client, maliciousAccount, maliciousAccount, 0, config.assetIndex); // opt in transaction
-  // await transferASA(client, openAccount, maliciousAccount, 2000000, config.assetIndex); // 5 algos
 }
 
 module.exports = initAccounts;

--- a/lib/teal/test/initExecutor.js
+++ b/lib/teal/test/initExecutor.js
@@ -7,22 +7,22 @@ const { transferFunds, transferASA } = require('../utils');
  * @return {Promise<void>}
  */
 
-async function initExecutor(config, type, optIn) {
+async function initExecutor(config, type, optIn, note) {
 
   // If we are overriding the default creator account
 
   const { client, openAccount, executorAccount, assetId } = config;
 
-  await transferFunds(client, openAccount, executorAccount, 2000000);
+  await transferFunds(client, openAccount, executorAccount, 2000000, note);
   
   if (type === 'sell' && optIn === true) {
-    await transferASA(client, executorAccount, executorAccount, 0, assetId); // opt in transaction
+    await transferASA(client, executorAccount, executorAccount, 0, assetId, note); // opt in transaction
   }
 
   if (type === 'buy') {
     //executor is willing to sell an asset
-    await transferASA(client, executorAccount, executorAccount, 0, assetId); // opt in transaction
-    await transferASA(client, openAccount, executorAccount, 2000000, assetId); //provide executor account with assset to sell
+    await transferASA(client, executorAccount, executorAccount, 0, assetId, note); // opt in transaction
+    await transferASA(client, openAccount, executorAccount, 2000000, assetId, note); //provide executor account with assset to sell
   }
 }
 

--- a/lib/teal/utils.js
+++ b/lib/teal/utils.js
@@ -223,14 +223,14 @@ async function closeAccount(client, fromAccount, toAccount) {
  * @param {number} amount
  * @return {Promise<void>}
  */
-async function transferFunds(client, fromAccount, toAccount, amount) {
+async function transferFunds(client, fromAccount, toAccount, amount, note) {
   const _suggestedParams = await client.getTransactionParams().do();
   const fundTxn = algosdk.makePaymentTxnWithSuggestedParams(
     fromAccount.addr,
     toAccount.addr,
     amount,
     undefined,
-    undefined,
+    note,
     _suggestedParams,
     undefined
   );
@@ -327,7 +327,7 @@ function groupAndSignTransactions(outerTxns) {
  * @param {string|number} assetId
  * @return {Promise<void>}
  */
-async function transferASA(client, fromAccount, toAccount, amount, assetId) {
+async function transferASA(client, fromAccount, toAccount, amount, assetId, note) {
   const _suggestedParams = await client.getTransactionParams().do();
 
   const asaTransferTxn = algosdk.makeAssetTransferTxnWithSuggestedParams(
@@ -336,7 +336,7 @@ async function transferASA(client, fromAccount, toAccount, amount, assetId) {
     undefined,
     undefined,
     amount,
-    undefined,
+    note,
     assetId,
     _suggestedParams,
     undefined


### PR DESCRIPTION
# ℹ Overview
The positive teal tests now provide a note that can be viewed on algo explorer that describes what is being tested, the relevant prices and amounts, as well as the relevant creator and executor accounts if they exist. 
The details of the notes can be expanded further if needed.



### 📝 Related Issues
#290 


