### PR TITLE
✅Added logs and defensively throw an error when stale session detected

### DIFF
--- a/lib/wallet/connectors/WalletConnect.js
+++ b/lib/wallet/connectors/WalletConnect.js
@@ -16,6 +16,7 @@ let connector;
  */
 function makeConnector() {
   if (typeof window !== 'undefined') {
+    console.log('We are in the make connector section of the SDK');
     logger.info('Browser');
     if (typeof connector === 'undefined') {
       const WalletConnect = require('@walletconnect/client').default;
@@ -24,6 +25,8 @@ function makeConnector() {
         bridge: 'https://bridge.walletconnect.org',
         qrcodeModal: require('algorand-walletconnect-qrcode-modal'),
       });
+
+      console.log('WalletConnect: ' + WalletConnect);
     }
   } else {
     logger.info('Node');

--- a/lib/wallet/signers/WalletConnect.js
+++ b/lib/wallet/signers/WalletConnect.js
@@ -10,6 +10,15 @@ const groupBy = require('../../utils/groupBy');
  * @return {Promise<*>}
  */
 async function signer(orders) {
+  console.log(`Start of wallet connect signing. 
+  instance currently looks like:
+  ${JSON.stringify(this)}
+  `);
+
+  const walletConnectSessionStorage = JSON.parse(localStorage.getItem('walletconnect'));
+  console.log(`Wallet Connect session storage ${JSON.stringify(walletConnectSessionStorage)}`);
+  if (!walletConnectSessionStorage?.connected) throw new TypeError('Stale wallet session please refresh and try again');
+
   const orderTxns = orders.map((execObj) => execObj.contract.txns);
 
   orderTxns.forEach((outerTxns) => algosdk.assignGroupID(
@@ -34,7 +43,17 @@ async function signer(orders) {
 
   const request = formatJsonRpcRequest('algo_signTxn', [encodedTxns]);
 
+  console.log('WalletConnect signing right before sending txns to the user ');
+
   const result = await this.sendCustomRequest(request);
+
+  console.log(`
+  WalletConnect Tranasactions have been succesfully signed
+  If infinite loading occurs after this statement it must be an issue with sending the txn
+
+  What the instance looks like afterwards
+  ${JSON.stringify(this)}
+  `);
 
 
   const resultsFormatted = result.map((element, idx) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algodex/algodex-sdk",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "API calls for interacting with the Algorand blockchain",
   "main": "lib/index.js",
   "browserslist": [


### PR DESCRIPTION
# ℹ Overview
Added logs related to the connector instance and for the Session Storage that walletconnect independently injects into our app.

The first defensive error I implemented was the simplest: Checking to see if walletconnect session is connected.

This could resolve the issue entirely, but if it doesn't then it also gives us an analytical starting point to identify the mismatches between the `this` connector and the `walletConnectSessionStorage` information. Different handshake topics etc.... 

### 📝 Related Issues
#297 

