### PR TITLE
🐞 Fix: only add the x-api-key if purestake uri detected

### DIFF
--- a/lib/AlgodexApi.js
+++ b/lib/AlgodexApi.js
@@ -264,26 +264,42 @@ AlgodexApi.prototype = {
       this.algod =
         config.algod instanceof algosdk.Algodv2 ?
           config.algod :
-          new algosdk.Algodv2(
-              config.algod.token,
-              config.algod.uri,
-              config.algod.port || '',
-              {
-                'x-api-key': config.algod.token, // For Purestake
-              },
-          );
+          config.algod.uri.endsWith('ps2') ?
+
+            new algosdk.Algodv2(
+                config.algod.token,
+                config.algod.uri,
+                config.algod.port || '',
+                {
+                  'x-api-key': config.algod.token, // For Purestake
+                },
+            ) :
+            new algosdk.Algodv2(
+                config.algod.token,
+                config.algod.uri,
+                config.algod.port || '',
+            )
+      ;
 
       this.indexer =
         config.indexer instanceof algosdk.Indexer ?
           config.indexer :
-          new algosdk.Indexer(
-              config.indexer.token,
-              config.indexer.uri,
-              config.indexer.port || '',
-              {
-                'x-api-key': config.indexer.token, // For Purestake
-              },
-          );
+
+          config.indexer.uri.endsWith('idx2') ?
+
+            new algosdk.Indexer(
+                config.indexer.token,
+                config.indexer.uri,
+                config.indexer.port || '',
+                {
+                  'x-api-key': config.indexer.token, // For Purestake
+                },
+            ) :
+            new algosdk.Indexer(
+                config.indexer.token,
+                config.indexer.uri,
+                config.indexer.port || '',
+            );
       // this.dexd = new AlgodexClient(config.dexd.uri);
 
       this.http = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algodex/algodex-sdk",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "API calls for interacting with the Algorand blockchain",
   "main": "lib/index.js",
   "browserslist": [


### PR DESCRIPTION
# ℹ Overview
`x-api-key` is only added to client and indexer when purestake uri is detected
### 📝 Related Issues

#306 #282 


