### PR TITLE
🐞 Price fix for taker order execution

### DIFF
--- a/lib/order/structure/getMakerTakerOrders.js
+++ b/lib/order/structure/getMakerTakerOrders.js
@@ -70,7 +70,11 @@ async function getMakerTakerOrders(api, order) {
    * Starts with available Taker Transactions
    * @type {Array<Order>}
    */
-  const orders = [...await getTakerOrders(api, {...order, execution: 'taker'})];
+
+  const originalPrice = order.price;
+  const roundedTakerPrice = order.type === 'buy'? order.price+= 0.0000009999999 : order. price-= 0.0000009999999;
+
+  const orders = [...await getTakerOrders(api, {...order, price: roundedTakerPrice, execution: 'taker'})];
 
   logger.debug( `getMakerTakerOrders: Created ${orders.length} Taker Order(s)`);
 
@@ -92,6 +96,7 @@ async function getMakerTakerOrders(api, order) {
     orders.push(
         await withMakerTxns(api, await compile({
           ...order,
+          price: originalPrice,
           execution: 'maker',
           amount: remainder,
           total: remainder * order.price,


### PR DESCRIPTION
# ℹ Overview
Temporarily bump the unformatted price of taker orders because taker execution does an initial filtering of potential orders based on the unformatted price and the unformatted price of bot orders could be of a higher precision than that of unformatted prices placed on the front end.  

### 📝 Related Issues
#315 


