### PR TITLE
321 fix optional callbackfn throws error when checking type when not passed in

### DIFF
--- a/lib/AlgodexApi.js
+++ b/lib/AlgodexApi.js
@@ -504,10 +504,10 @@ AlgodexApi.prototype = {
     }
     let resOrders;
 
-    if (order.wallet.type === 'my-algo-wallet' && typeof callbackFn === 'function') {
+    if (order?.wallet?.type === 'my-algo-wallet' && typeof callbackFn === 'function') {
       callbackFn('Awaiting Signature - Sign the transaction with the MyAlgo pop-up');
     }
-    if (order.wallet.type === 'wallet-connect' && typeof callbackFn === 'function') {
+    if (order?.wallet?.type === 'wallet-connect' && typeof callbackFn === 'function') {
       callbackFn('Awaiting Signature - Check your wallet app to sign the transaction');
     }
     const execute = composePromise(

--- a/lib/AlgodexApi.js
+++ b/lib/AlgodexApi.js
@@ -553,11 +553,11 @@ AlgodexApi.prototype = {
   async closeOrder(order, callbackFn) {
     let resOrders;
 
-    if (order.wallet.type === 'my-algo-wallet' && typeof callbackFn === 'function') {
+    if (order?.wallet?.type === 'my-algo-wallet' && typeof callbackFn === 'function') {
       callbackFn('Awaiting Signature - Sign the transaction with the MyAlgo pop-up');
     }
 
-    if (order.wallet.type === 'wallet-connect' && typeof callbackFn === 'function') {
+    if (order?.wallet?.type === 'wallet-connect' && typeof callbackFn === 'function') {
       callbackFn('Awaiting Signature - Check your wallet app to sign the transaction');
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algodex/algodex-sdk",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "API calls for interacting with the Algorand blockchain",
   "main": "lib/index.js",
   "browserslist": [


### PR DESCRIPTION
# ℹ Overview

Only check the wallet property on an order if it is supplied. 

### 📝 Related Issues
#321 


