### PR TITLE
add etag into data

### DIFF
--- a/lib/http/HTTPClient.js
+++ b/lib/http/HTTPClient.js
@@ -128,8 +128,10 @@ Object.assign(HTTPClient.prototype, {
           .then((res) => {
             if (res && res.status === 200) {
               const etag = res.headers.etag;
+              res.data.etag = etag;
               this.cache.res[url] = res;
               this.cache.etag[url] = etag;
+              // console.log('NOT returning cache for ' + url);
               return res;
             } else {
               throw new Error('Unexpected Status');
@@ -138,6 +140,7 @@ Object.assign(HTTPClient.prototype, {
           .catch((error) => {
             const errorResp = error.response;
             if (errorResp && errorResp.status === 304) {
+              // console.log('returning cache for ' + url);
               return this.cache.res[url];
             } else {
               throw new Error(`Invalid response: ${error.message}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algodex/algodex-sdk",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "API calls for interacting with the Algorand blockchain",
   "main": "lib/index.js",
   "browserslist": [


### PR DESCRIPTION
# ℹ Overview

Add etag into the response data from the SDK. This allows for data equality checks with a far less CPU burden.

### 📝 Related Issues

<!--- Pin any related issues -->

### 🔐 Acceptance:
<!-- Ensure the following are completed and mark the result with an [X] -->

- [ ] `yarn test` passes
